### PR TITLE
Display error when Component contains Application Id part

### DIFF
--- a/src/main/java/com/distillery/intentsender/data/history/ApplicationIdFromComponentExtractor.kt
+++ b/src/main/java/com/distillery/intentsender/data/history/ApplicationIdFromComponentExtractor.kt
@@ -1,8 +1,7 @@
 package com.distillery.intentsender.data.history
 
 import com.distillery.intentsender.domain.command.Command
-
-private const val APPLICATION_ID_IN_COMPONENT_SEPARATOR = '/'
+import com.distillery.intentsender.utils.APPLICATION_ID_IN_COMPONENT_SEPARATOR
 
 /**
  * Extracts application id part from component and stores is to corresponding field.

--- a/src/main/java/com/distillery/intentsender/domain/command/CommandParamsValidator.kt
+++ b/src/main/java/com/distillery/intentsender/domain/command/CommandParamsValidator.kt
@@ -2,6 +2,7 @@ package com.distillery.intentsender.domain.command
 
 import com.distillery.intentsender.domain.command.CommandParamsValidator.ValidationResult.Invalid
 import com.distillery.intentsender.domain.command.CommandParamsValidator.ValidationResult.Valid
+import com.distillery.intentsender.utils.APPLICATION_ID_IN_COMPONENT_SEPARATOR
 
 /** Validates if [Command]'s fields are properly set and ready to be converted to a reliable command. */
 class CommandParamsValidator {
@@ -9,7 +10,8 @@ class CommandParamsValidator {
     fun validate(command: Command): ValidationResult {
         val errors = mutableListOf<Invalid.Error>()
 
-        errors.addAll(validateComponentAndApplicationIfSet(command))
+        errors.addAll(validateComponent(command))
+        errors.addAll(validateApplicationId(command))
 
         return if (errors.isEmpty()) {
             Valid
@@ -18,17 +20,24 @@ class CommandParamsValidator {
         }
     }
 
-    /**
-     * Checks that component and application id are both set or both empty.
-     *
-     * Rationale: result command merges them together in a form of "applicationId/component", like:
-     * "com.example.app/com.some.package.some.component.Class"
-     */
-    private fun validateComponentAndApplicationIfSet(command: Command): List<Invalid.Error> {
+    /** Validates component info. */
+    private fun validateComponent(command: Command): List<Invalid.Error> {
         val errors = mutableListOf<Invalid.Error>()
-        if (!command.component.isNullOrBlank() && command.applicationId.isNullOrBlank()) {
-            errors.add(Invalid.Error.APPLICATION_ID_MISSING)
+        if (!command.component.isNullOrBlank()) {
+            if (command.applicationId.isNullOrBlank()) {
+                // Application Id is expected to be set when Component is set
+                errors.add(Invalid.Error.APPLICATION_ID_MISSING)
+            }
+            if (command.component.contains(APPLICATION_ID_IN_COMPONENT_SEPARATOR)) {
+                errors.add(Invalid.Error.COMPONENT_HAS_APPLICATION_ID)
+            }
         }
+        return errors
+    }
+
+    /** Validates application id info. */
+    private fun validateApplicationId(command: Command): List<Invalid.Error> {
+        val errors = mutableListOf<Invalid.Error>()
         if (!command.applicationId.isNullOrBlank() && command.component.isNullOrBlank()) {
             errors.add(Invalid.Error.COMPONENT_MISSING)
         }
@@ -44,6 +53,7 @@ class CommandParamsValidator {
             enum class Error {
                 APPLICATION_ID_MISSING,
                 COMPONENT_MISSING,
+                COMPONENT_HAS_APPLICATION_ID,
             }
         }
     }

--- a/src/main/java/com/distillery/intentsender/ui/MainToolWindow.java
+++ b/src/main/java/com/distillery/intentsender/ui/MainToolWindow.java
@@ -1,10 +1,13 @@
 package com.distillery.intentsender.ui;
 
-import android.util.Log;
 import com.android.ddmlib.IDevice;
-import com.distillery.intentsender.utils.documentlisteners.ErrorRemovalDocumentListener;
+import com.distillery.intentsender.adb.AdbHelper;
+import com.distillery.intentsender.domain.command.Command;
+import com.distillery.intentsender.models.ExtraField;
+import com.distillery.intentsender.models.IntentFlags;
+import com.distillery.intentsender.ui.views.*;
 import com.distillery.intentsender.utils.JLabelExtensionsKt;
-import com.distillery.intentsender.utils.documentlisteners.SilentDocumentListener;
+import com.distillery.intentsender.utils.documentlisteners.ErrorRemovalDocumentListener;
 import com.distillery.intentsender.utils.documentlisteners.TextChangedListener;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.util.TreeJavaClassChooserDialog;
@@ -16,18 +19,12 @@ import com.intellij.ui.Gray;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBList;
 import com.intellij.ui.components.JBScrollPane;
-import com.distillery.intentsender.domain.command.Command;
-import com.distillery.intentsender.models.ExtraField;
-import com.distillery.intentsender.models.IntentFlags;
-import com.distillery.intentsender.adb.AdbHelper;
-import com.distillery.intentsender.ui.views.*;
 import kotlin.Unit;
 import org.apache.commons.lang3.ArrayUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import javax.swing.event.DocumentEvent;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.table.TableColumn;
 import java.awt.*;
@@ -35,7 +32,8 @@ import java.awt.event.ItemEvent;
 import java.io.File;
 import java.util.List;
 
-import static com.distillery.intentsender.domain.command.CommandParamsValidator.*;
+import static com.distillery.intentsender.domain.command.CommandParamsValidator.ValidationResult;
+import static com.distillery.intentsender.domain.command.CommandParamsValidator.ValidationResult.Invalid.Error.*;
 
 public class MainToolWindow implements MainToolWindowContract.View {
 	public static final String ISSUES_LINK = "https://github.com/WeezLabs/idea-intent-sender-plugin/issues";
@@ -406,18 +404,26 @@ public class MainToolWindow implements MainToolWindowContract.View {
 	@Override
 	public void displayParamsErrors(@NotNull List<? extends ValidationResult.Invalid.Error> errors) {
 		errors.forEach(error -> {
-            if (error == ValidationResult.Invalid.Error.APPLICATION_ID_MISSING) {
+            if (error == APPLICATION_ID_MISSING) {
                 showApplicationIdMissingError();
-            } else if (error == ValidationResult.Invalid.Error.COMPONENT_MISSING) {
-                showComponentMissingError();
-            }
+            } else if (error == COMPONENT_MISSING) {
+				showComponentMissingError();
+			} else if (error == COMPONENT_HAS_APPLICATION_ID) {
+				showComponentHasApplicationIdError();
+			}
 		});
 	}
 
-    private void showComponentMissingError() {
+	private void showComponentMissingError() {
         JLabelExtensionsKt.showError(componentLabel, AllIcons.General.Error,
                 "Component must be set when application id is set");
     }
+
+	private void showComponentHasApplicationIdError() {
+		String message = "Component must not contain application id. Use Application Id field." +
+				"\nHint: move everything to the left of the slash";
+		JLabelExtensionsKt.showError(componentLabel, AllIcons.General.Error, message);
+	}
 
     private void showApplicationIdMissingError() {
 		JLabelExtensionsKt.showError(applicationIdLabel, AllIcons.General.Error,

--- a/src/main/java/com/distillery/intentsender/utils/ApplicationIdConstants.kt
+++ b/src/main/java/com/distillery/intentsender/utils/ApplicationIdConstants.kt
@@ -1,0 +1,3 @@
+package com.distillery.intentsender.utils
+
+const val APPLICATION_ID_IN_COMPONENT_SEPARATOR = '/'

--- a/src/test/java/com/distillery/intentsender/domain/command/CommandParamsValidatorTest.kt
+++ b/src/test/java/com/distillery/intentsender/domain/command/CommandParamsValidatorTest.kt
@@ -1,9 +1,7 @@
 package com.distillery.intentsender.domain.command
 
-import com.distillery.intentsender.adb.AdbHelper.CommandType
 import com.distillery.intentsender.domain.command.CommandParamsValidator.ValidationResult
-import com.distillery.intentsender.domain.command.CommandParamsValidator.ValidationResult.Invalid.Error.APPLICATION_ID_MISSING
-import com.distillery.intentsender.domain.command.CommandParamsValidator.ValidationResult.Invalid.Error.COMPONENT_MISSING
+import com.distillery.intentsender.domain.command.CommandParamsValidator.ValidationResult.Invalid.Error.*
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -34,6 +32,17 @@ class CommandParamsValidatorTest {
         val result = validator.validate(command)
 
         assertResultIsInvalid(result, APPLICATION_ID_MISSING)
+    }
+
+    @Test
+    fun `error returned when component contains application`() {
+        val command = createCommandStub(
+            component = "appId/component_stub"
+        )
+
+        val result = validator.validate(command)
+
+        assertResultIsInvalid(result, COMPONENT_HAS_APPLICATION_ID)
     }
 
     private fun assertResultIsInvalid(


### PR DESCRIPTION
With the separate field for Application Id, someone may still try to use Component to declare Application Id. This PR adds one more validation and plugin will display error if Component field contains Application Id part