### PR TITLE
Remove package split logic after component was selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 # Intent Sender Changelog
 
-## [Unreleased]
+## [0.12.0]
+### Fixed
+- Disable automatic package-based application id extraction from component string
 
 ## [0.11.0]
 ### Added

--- a/src/main/java/com/distillery/intentsender/ui/MainToolWindowPresenter.kt
+++ b/src/main/java/com/distillery/intentsender/ui/MainToolWindowPresenter.kt
@@ -191,40 +191,8 @@ class MainToolWindowPresenter(
 
     override fun onComponentSelected(selectedClass: PsiClass?) {
         if (selectedClass != null) {
-            val androidPackage = getAndroidPackage(selectedClass)
-            var fullComponentName = selectedClass.qualifiedName
-            if (!androidPackage.isNullOrEmpty()
-                && fullComponentName != null
-            ) {
-                val packageIndex = fullComponentName.indexOf(androidPackage)
-                if (packageIndex != -1) {
-                    val builder = StringBuilder(fullComponentName)
-                    fullComponentName = builder.insert(packageIndex + androidPackage.length, "/").toString()
-                }
-                view.setUser(androidPackage)
-            }
-            view.setComponent(fullComponentName)
+            view.setComponent(selectedClass.qualifiedName)
         }
-    }
-
-    /**
-     * Gets android app package from selected class
-     *
-     * @return Package or null if package cannot be parsed from sources
-     */
-    private fun getAndroidPackage(selectedClass: PsiClass): String? {
-        val projectRootManager = ProjectRootManager.getInstance(selectedClass.project)
-        val selectedClassVirtualFile = selectedClass.containingFile.virtualFile
-        val module = projectRootManager.fileIndex.getModuleForFile(selectedClassVirtualFile)
-            ?: return null
-        val facetManager = FacetManager.getInstance(module)
-        val facet = facetManager.getFacetByType(AndroidFacet.ID) ?: return null
-        val manifestFile = AndroidRootUtil.getPrimaryManifestFile(facet) ?: return null
-        val manifest = AndroidUtils.loadDomElement(facet.module, manifestFile, Manifest::class.java)
-            ?: return null
-        val rootPackage = manifest.getPackage()
-        // TODO(vfarafonov, 1/3/21): use application id instead of package from module's manifest.
-        return rootPackage.stringValue
     }
 
     override fun onFlagsClicked() {

--- a/src/test/java/com/distillery/intentsender/ui/MainToolWindowPresenterTest.kt
+++ b/src/test/java/com/distillery/intentsender/ui/MainToolWindowPresenterTest.kt
@@ -6,6 +6,7 @@ import com.distillery.intentsender.domain.command.CommandParamsValidator.Validat
 import com.distillery.intentsender.domain.command.CommandParamsValidator.ValidationResult.Invalid.Error
 import com.distillery.intentsender.testutils.stubMock
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiClass
 import com.nhaarman.mockitokotlin2.*
 import org.junit.Test
 
@@ -45,6 +46,18 @@ class MainToolWindowPresenterTest {
 
         verify(view).enableStartButtons(false)
         verify(view, never()).displayParamsErrors(any())
+    }
+
+    @Test
+    fun `component in view updated after it was selected`() {
+        val qualifiedNameStub = "stub"
+        val component: PsiClass = mock() {
+            on { qualifiedName } doReturn qualifiedNameStub
+        }
+
+        presenter.onComponentSelected(component)
+
+        verify(view).setComponent(qualifiedNameStub)
     }
 
     private fun callSendCommandClickedWithStubs() {


### PR DESCRIPTION
There was a logic which parses package root from Android project. But what we actually need is Application ID. So, having package ID extracted may only break app logic. For now, I decided to remove that logic. 
In the future, the logic I removed may be replaced by application ID parsing from Android projects.